### PR TITLE
Fixed the german translation of "Support MultiMC"

### DIFF
--- a/de.po
+++ b/de.po
@@ -2786,7 +2786,7 @@ msgstr "Nach Updates für %1 suchen."
 #, qt-format
 msgctxt "MainWindow|"
 msgid "Support %1"
-msgstr "%1 Unterstützten"
+msgstr "%1 unterstützen"
 
 #: src/launcher/ui/MainWindow.cpp:405
 #, qt-format


### PR DESCRIPTION
Changed the german translation of the Patreon-donation site in the main-window called "Support MultiMC" in english from "MultiMC Unterstützten" to "MultiMC unterstützen". Corrects the case of the first letter and removes the "t" after the "z" for it to have the right conjugation.